### PR TITLE
Use private realay enpoint

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -41,7 +41,6 @@ def nostrmarket_start():
         # wait for 'nostrclient' extension to initialize
         await asyncio.sleep(10)
         await nostr_client.run_forever()
-        raise ValueError("Must reconnect to websocket")
 
     async def _wait_for_nostr_events():
         # wait for this extension to initialize

--- a/config.json
+++ b/config.json
@@ -3,5 +3,5 @@
   "short_description": "Nostr Webshop/market on LNbits",
   "tile": "/nostrmarket/static/images/bitcoin-shop.png",
   "contributors": [],
-  "min_lnbits_version": "0.11.0"
+  "min_lnbits_version": "0.12.0"
 }

--- a/nostr/nostr_client.py
+++ b/nostr/nostr_client.py
@@ -8,7 +8,7 @@ from loguru import logger
 from websocket import WebSocketApp
 
 from lnbits.app import settings
-from lnbits.helpers import urlsafe_short_hash
+from lnbits.helpers import encrypt_internal_message, urlsafe_short_hash
 
 from .event import NostrEvent
 
@@ -34,8 +34,9 @@ class NostrClient:
             self.recieve_event_queue.put_nowait(ValueError("Websocket close."))
 
         logger.debug(f"Subscribing to websockets for nostrclient extension")
+        relay_endpoint = encrypt_internal_message("relay")
         ws = WebSocketApp(
-            f"ws://localhost:{settings.port}/nostrclient/api/v1/relay",
+            f"ws://localhost:{settings.port}/nostrclient/api/v1/{relay_endpoint}",
             on_message=on_message,
             on_open=on_open,
             on_close=on_close,

--- a/nostr/nostr_client.py
+++ b/nostr/nostr_client.py
@@ -94,7 +94,7 @@ class NostrClient:
         await self.send_req_queue.put(["REQ", self.subscription_id] + merchant_filters)
 
         logger.debug(
-            f"Subscribed to events for: {len(public_keys)} keys. New subscription id: {self.subscription_id}"
+            f"Subscribing to events for: {len(public_keys)} keys. New subscription id: {self.subscription_id}"
         )
 
     async def merchant_temp_subscription(self, pk, duration=10):

--- a/tasks.py
+++ b/tasks.py
@@ -43,6 +43,6 @@ async def wait_for_nostr_events(nostr_client: NostrClient):
             while True:
                 message = await nostr_client.get_event()
                 await process_nostr_message(message)
-        except:
-            logger.warning("Subcription failed. Will retry in one minute.")
-            await asyncio.sleep(60)
+        except Exception as e:
+            logger.warning(f"Subcription failed. Will retry in one minute: {e}")
+            await asyncio.sleep(10)

--- a/tasks.py
+++ b/tasks.py
@@ -1,4 +1,7 @@
 from asyncio import Queue
+import asyncio
+
+from loguru import logger
 
 from lnbits.core.models import Payment
 from lnbits.tasks import register_invoice_listener
@@ -33,9 +36,13 @@ async def on_invoice_paid(payment: Payment) -> None:
 
 
 async def wait_for_nostr_events(nostr_client: NostrClient):
-
-    await subscribe_to_all_merchants()
-
     while True:
-        message = await nostr_client.get_event()
-        await process_nostr_message(message)
+        try:
+            await subscribe_to_all_merchants()
+
+            while True:
+                message = await nostr_client.get_event()
+                await process_nostr_message(message)
+        except:
+            logger.warning("Subcription failed. Will retry in one minute.")
+            await asyncio.sleep(60)


### PR DESCRIPTION
Connect to the `nostrclient` web-socket via private endpoint.
Improve web-socket re-connect logic.