### PR TITLE
Fix error: boolean for `showKeys` does not update child component when hidden from index

### DIFF
--- a/static/components/merchant-details/merchant-details.html
+++ b/static/components/merchant-details/merchant-details.html
@@ -15,7 +15,7 @@
           >
         </q-item-section>
       </q-item>
-      <q-item @click="toggleMerchantKeys" clickable v-close-popup>
+      <q-item @click="toggleShowKeys" clickable v-close-popup>
         <q-item-section>
           <q-item-label v-if="!showKeys">Show Keys</q-item-label>
           <q-item-label v-else>Hide Keys</q-item-label>

--- a/static/components/merchant-details/merchant-details.js
+++ b/static/components/merchant-details/merchant-details.js
@@ -2,18 +2,16 @@ async function merchantDetails(path) {
   const template = await loadTemplateAsync(path)
   Vue.component('merchant-details', {
     name: 'merchant-details',
-    props: ['merchant-id', 'adminkey', 'inkey'],
+    props: ['merchant-id', 'adminkey', 'inkey','showKeys'],
     template,
 
     data: function () {
       return {
-        showKeys: false
       }
     },
     methods: {
-      toggleMerchantKeys: async function () {
-        this.showKeys = !this.showKeys
-        this.$emit('show-keys', this.showKeys)
+      toggleShowKeys: async function () {
+        this.$emit('toggle-show-keys')
       },
 
       republishMerchantData: async function () {

--- a/static/js/index.js
+++ b/static/js/index.js
@@ -58,8 +58,8 @@ const merchant = async () => {
       showImportKeysDialog: async function () {
         this.importKeyDialog.show = true
       },
-      toggleMerchantKeys: function (value) {
-        this.showKeys = value
+      toggleShowKeys: function () {
+        this.showKeys = !this.showKeys
       },
       toggleMerchantState: async function () {
         const merchant = await this.getMerchant()

--- a/templates/nostrmarket/index.html
+++ b/templates/nostrmarket/index.html
@@ -11,7 +11,8 @@
                 :merchant-id="merchant.id"
                 :inkey="g.user.wallets[0].inkey"
                 :adminkey="g.user.wallets[0].adminkey"
-                @show-keys="toggleMerchantKeys"
+                :show-keys="showKeys"
+                @toggle-show-keys="toggleShowKeys"
                 @merchant-deleted="handleMerchantDeleted"
               ></merchant-details>
             </div>


### PR DESCRIPTION
The `merchant-details` component (<strike>which I propose calling `merchant-dropdown` for better clarity</strike>) has its own independent boolean for showKeys from the parent `index` allowing the values to become out of sync.
Instead, `showkeys` is passed as a prop to the `merchant-dropdown` component. `merchant-dropdown` toggles the boolean using an emit, which fixes the issue.

edit: removed renaming the component, simply fix showKeys bug