### PR TITLE
Fix : Add URL encoding for nostr websocket token

### DIFF
--- a/nostr/nostr_client.py
+++ b/nostr/nostr_client.py
@@ -3,6 +3,7 @@ import json
 from asyncio import Queue
 from threading import Thread
 from typing import Callable, List, Optional
+from urllib.parse import quote_plus
 
 from loguru import logger
 from websocket import WebSocketApp
@@ -31,6 +32,8 @@ class NostrClient:
         logger.debug(f"Connecting to websockets for 'nostrclient' extension...")
 
         relay_endpoint = encrypt_internal_message("relay")
+        # URL encode the encrypted token including forward slashes
+        relay_endpoint = quote_plus(relay_endpoint)
         on_open, on_message, on_error, on_close = self._ws_handlers()
         ws = WebSocketApp(
             f"ws://localhost:{settings.port}/nostrclient/api/v1/{relay_endpoint}",


### PR DESCRIPTION
### Problem:
The websocket connection to /nostrclient/api/v1/{token} was failing with 403 errors because the encrypted token contained unencoded forward slashes (/). This caused the URL routing to interpret parts of the token as path segments.

### Solution:
Added urllib.parse.quote_plus() to properly encode the encrypted token before appending the timestamp. quote_plus() is used instead of quote() because:
1. It encodes forward slashes (/) to %2F
2. It handles all special characters that could interfere with URL routing

The encoded token ensures the full encrypted value is treated as a single URL segment, allowing proper decryption and validation on the server side.

### Testing:
- [ ] Verify websocket connections succeeds without 403 errors
- [ ] Confirm token decryption works with encoded values