### PR TITLE
 FIX: add urlsafe=True parameter to encrypt_internal_message #34 

### DIFF
--- a/nostr/nostr_client.py
+++ b/nostr/nostr_client.py
@@ -30,7 +30,7 @@ class NostrClient:
     async def connect_to_nostrclient_ws(self) -> WebSocketApp:
         logger.debug(f"Connecting to websockets for 'nostrclient' extension...")
 
-        relay_endpoint = encrypt_internal_message("relay")
+        relay_endpoint = encrypt_internal_message("relay", urlsafe=True)
         on_open, on_message, on_error, on_close = self._ws_handlers()
         ws = WebSocketApp(
             f"ws://localhost:{settings.port}/nostrclient/api/v1/{relay_endpoint}",


### PR DESCRIPTION
### History

In lnbits/lnbits#2984 we added a boolean flag for urlsafe encryption to fix API requests failing with a `403` due to characters like `/` resulting from the non-urlsafe encryption

Subsequently, in lnbits/nostrclient#34 , we made sure that decrypt_internal_message included the `urlsafe=True` parameter.

Finally, we need to add the parameter to the nostrmarket extension in order that it create a proper encrypted string for `relay_endpoint` that is urlsafe.

### Problem

Without urlsafe being explicitly set in the nostrmarket `encrypt_internal_message` function it may create a **non**-urlsafe encrypted string containing characters such as `/` leading to the API request to fail with a `403` status.

### Solution

Update nostrmarket `encrypt_internal` message with `urlsafe=True` boolean.

