### PR TITLE
fix: clean up UI layout and remove duplicates

### DIFF
--- a/templates/nostrmarket/components/merchant-tab.html
+++ b/templates/nostrmarket/components/merchant-tab.html
@@ -1,102 +1,95 @@
 <div>
   <div class="row q-col-gutter-md">
+    <!-- Left Column - Merchant Controls -->
     <div class="col-12 col-md-8">
-      <div class="row items-center q-col-gutter-sm q-mb-md">
-        <div class="col-12 col-sm-auto">
-          <merchant-details
-            :merchant-id="merchantId"
-            :inkey="inkey"
-            :adminkey="adminkey"
-            :show-keys="showKeys"
-            @toggle-show-keys="toggleShowKeys"
-            @merchant-deleted="handleMerchantDeleted"
-          ></merchant-details>
-        </div>
-        <div class="col-12 col-sm-auto q-mx-sm">
-          <div class="row items-center no-wrap">
-            <q-toggle
-              :model-value="merchantActive"
-              @update:model-value="toggleMerchantState()"
-              size="md"
-              checked-icon="check"
-              color="primary"
-              unchecked-icon="clear"
-            />
-            <span
-              class="q-ml-sm"
-              v-text="merchantActive ? 'Accepting Orders': 'Orders Paused'"
-            ></span>
-          </div>
-        </div>
-        <div v-if="isAdmin" class="col-12 col-sm-auto q-ml-sm-auto">
-          <q-btn
-            label="Restart Nostr Connection"
-            color="grey"
-            outline
-            size="sm"
-            @click="restartNostrConnection"
-          >
-            <q-tooltip>
-              Restart the connection to the nostrclient extension
-            </q-tooltip>
-          </q-btn>
-        </div>
-      </div>
-      <div v-if="showKeys" class="q-mt-md">
-        <div class="row q-mb-md">
-          <div class="col">
-            <q-btn
-              unelevated
-              color="grey"
-              outline
-              @click="hideKeys"
-              class="float-left"
-              >Hide Keys</q-btn
-            >
-          </div>
-        </div>
-        <div class="row">
-          <div class="col">
-            <key-pair
-              :public-key="publicKey"
-              :private-key="privateKey"
-            ></key-pair>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div class="col-12 col-md-4">
-      <q-card flat bordered>
+      <q-card>
         <q-card-section>
-          <h6 class="text-subtitle1 q-my-none">Nostr Market Extension</h6>
+          <div class="row items-center q-col-gutter-sm">
+            <div class="col-12 col-sm-auto">
+              <merchant-details
+                :merchant-id="merchantId"
+                :inkey="inkey"
+                :adminkey="adminkey"
+                :show-keys="showKeys"
+                @toggle-show-keys="toggleShowKeys"
+                @merchant-deleted="handleMerchantDeleted"
+              ></merchant-details>
+            </div>
+            <div class="col-12 col-sm-auto q-mx-sm">
+              <div class="row items-center no-wrap">
+                <q-toggle
+                  :model-value="merchantActive"
+                  @update:model-value="toggleMerchantState()"
+                  size="md"
+                  checked-icon="check"
+                  color="primary"
+                  unchecked-icon="clear"
+                />
+                <span
+                  class="q-ml-sm"
+                  v-text="merchantActive ? 'Accepting Orders': 'Orders Paused'"
+                ></span>
+              </div>
+            </div>
+            <div v-if="isAdmin" class="col-12 col-sm-auto q-ml-sm-auto">
+              <q-btn
+                label="Restart Nostr Connection"
+                color="grey"
+                outline
+                size="sm"
+                @click="restartNostrConnection"
+              >
+                <q-tooltip>
+                  Restart the connection to the nostrclient extension
+                </q-tooltip>
+              </q-btn>
+            </div>
+          </div>
+        </q-card-section>
+        <q-card-section v-if="showKeys">
+          <div class="row q-mb-md">
+            <div class="col">
+              <q-btn
+                unelevated
+                color="grey"
+                outline
+                @click="hideKeys"
+                class="float-left"
+                >Hide Keys</q-btn
+              >
+            </div>
+          </div>
+          <div class="row">
+            <div class="col">
+              <key-pair
+                :public-key="publicKey"
+                :private-key="privateKey"
+              ></key-pair>
+            </div>
+          </div>
+        </q-card-section>
+      </q-card>
+    </div>
+
+    <!-- Right Column - Nostr Market Info -->
+    <div class="col-12 col-md-4">
+      <q-card>
+        <q-img
+          src="/nostrmarket/static/market/images/nostr-cover.png"
+          :ratio="3"
+          fit="cover"
+        ></q-img>
+        <q-card-section>
+          <div class="text-h6 q-mb-sm">Nostr Market</div>
+          <div class="text-body2 text-grey">
+            A decentralized marketplace extension for LNbits implementing the
+            NIP-15 protocol. Create stalls, list products, and accept Lightning
+            payments while communicating with customers via encrypted Nostr
+            direct messages.
+          </div>
         </q-card-section>
         <q-card-section class="q-pa-none">
-          <q-separator></q-separator>
-          <q-list>
-            <q-expansion-item group="api" dense icon="info" label="About">
-              <q-card>
-                <q-card-section>
-                  A decentralized marketplace powered by Nostr and Lightning
-                  Network. Create stalls, add products, and start selling with
-                  Bitcoin.
-                </q-card-section>
-              </q-card>
-            </q-expansion-item>
-            <q-expansion-item
-              group="api"
-              dense
-              icon="link"
-              label="Market Client"
-            >
-              <q-card>
-                <q-card-section>
-                  <a :href="marketClientUrl" target="_blank"
-                    >Open Market Client</a
-                  >
-                </q-card-section>
-              </q-card>
-            </q-expansion-item>
-          </q-list>
+          <q-list> {% include "nostrmarket/_api_docs.html" %} </q-list>
         </q-card-section>
       </q-card>
     </div>

--- a/templates/nostrmarket/index.html
+++ b/templates/nostrmarket/index.html
@@ -49,7 +49,71 @@
               style="min-width: 120px"
             ></q-tab>
           </q-tabs>
-          <div class="col-auto q-mr-md">
+          <div class="col-auto q-mr-md q-gutter-x-sm">
+            <q-btn-dropdown
+              v-if="g.user.admin"
+              :color="nostrStatusColor"
+              :label="nostrStatusLabel"
+              icon="sync"
+              split
+              unelevated
+              @click="restartNostrConnection"
+            >
+              <q-list>
+                <q-item clickable v-close-popup @click="restartNostrConnection">
+                  <q-item-section avatar>
+                    <q-icon name="refresh" color="primary"></q-icon>
+                  </q-item-section>
+                  <q-item-section>
+                    <q-item-label>Restart Connection</q-item-label>
+                    <q-item-label caption>
+                      Reconnect to the nostrclient extension
+                    </q-item-label>
+                  </q-item-section>
+                </q-item>
+                <q-item clickable v-close-popup @click="checkNostrStatus(true)">
+                  <q-item-section avatar>
+                    <q-icon name="wifi_find" color="primary"></q-icon>
+                  </q-item-section>
+                  <q-item-section>
+                    <q-item-label>Check Status</q-item-label>
+                    <q-item-label caption>
+                      Check connection to nostrclient
+                    </q-item-label>
+                  </q-item-section>
+                </q-item>
+                <q-separator></q-separator>
+                <q-item>
+                  <q-item-section>
+                    <q-item-label caption>
+                      <strong>Status:</strong>
+                      <q-badge
+                        :color="nostrStatus.connected ? 'green' : 'red'"
+                        class="q-ml-xs"
+                        v-text="nostrStatus.connected ? 'Connected' : 'Disconnected'"
+                      ></q-badge>
+                    </q-item-label>
+                    <q-item-label
+                      v-if="nostrStatus.relays_total > 0"
+                      caption
+                      class="q-mt-xs"
+                    >
+                      <strong>Relays:</strong>&nbsp;
+                      <span v-text="nostrStatus.relays_connected"></span>
+                      of
+                      <span v-text="nostrStatus.relays_total"></span>
+                      connected
+                    </q-item-label>
+                    <q-item-label
+                      v-if="nostrStatus.error"
+                      caption
+                      class="text-negative q-mt-xs"
+                      v-text="nostrStatus.error"
+                    ></q-item-label>
+                  </q-item-section>
+                </q-item>
+              </q-list>
+            </q-btn-dropdown>
             <q-btn-dropdown
               color="primary"
               label="Publish"
@@ -272,110 +336,6 @@
         </div>
       </q-card-section>
     </q-card>
-  </div>
-
-  <div class="col-12 col-md-5 q-gutter-y-md">
-    <div v-if="g.user.admin" class="col-12 q-mb-lg">
-      <q-card>
-        <q-card-section class="q-pa-md">
-          <q-btn-dropdown
-            :color="nostrStatusColor"
-            :label="nostrStatusLabel"
-            icon="sync"
-            split
-            @click="restartNostrConnection"
-          >
-            <q-list>
-              <q-item clickable v-close-popup @click="restartNostrConnection">
-                <q-item-section avatar>
-                  <q-icon name="refresh" color="primary"></q-icon>
-                </q-item-section>
-                <q-item-section>
-                  <q-item-label>Restart Connection</q-item-label>
-                  <q-item-label caption>
-                    Reconnect to the nostrclient extension
-                  </q-item-label>
-                </q-item-section>
-              </q-item>
-              <q-item clickable v-close-popup @click="checkNostrStatus(true)">
-                <q-item-section avatar>
-                  <q-icon name="wifi_find" color="primary"></q-icon>
-                </q-item-section>
-                <q-item-section>
-                  <q-item-label>Check Status</q-item-label>
-                  <q-item-label caption>
-                    Check connection to nostrclient
-                  </q-item-label>
-                </q-item-section>
-              </q-item>
-              <q-separator></q-separator>
-              <q-item>
-                <q-item-section>
-                  <q-item-label caption>
-                    <strong>Status:</strong>
-                    <q-badge
-                      :color="nostrStatus.connected ? 'green' : 'red'"
-                      class="q-ml-xs"
-                      v-text="nostrStatus.connected ? 'Connected' : 'Disconnected'"
-                    ></q-badge>
-                  </q-item-label>
-                  <q-item-label
-                    v-if="nostrStatus.relays_total > 0"
-                    caption
-                    class="q-mt-xs"
-                  >
-                    <strong>Relays:</strong>&nbsp;
-                    <span v-text="nostrStatus.relays_connected"></span>
-                    of
-                    <span v-text="nostrStatus.relays_total"></span>
-                    connected
-                  </q-item-label>
-                  <q-item-label
-                    v-if="nostrStatus.error"
-                    caption
-                    class="text-negative q-mt-xs"
-                    v-text="nostrStatus.error"
-                  ></q-item-label>
-                </q-item-section>
-              </q-item>
-            </q-list>
-          </q-btn-dropdown>
-        </q-card-section>
-      </q-card>
-    </div>
-    <div v-if="activeTab === 'merchant'" class="col-12">
-      <q-card>
-        <q-img
-          src="/nostrmarket/static/market/images/nostr-cover.png"
-          :ratio="3"
-          fit="cover"
-        ></q-img>
-        <q-card-section>
-          <div class="text-h6 q-mb-sm">Nostr Market</div>
-          <div class="text-body2 text-grey">
-            A decentralized marketplace extension for LNbits implementing the
-            NIP-15 protocol. Create stalls, list products, and accept Lightning
-            payments while communicating with customers via encrypted Nostr
-            direct messages.
-          </div>
-        </q-card-section>
-        <q-card-section class="q-pa-none">
-          <q-list> {% include "nostrmarket/_api_docs.html" %} </q-list>
-        </q-card-section>
-      </q-card>
-    </div>
-    <div v-if="merchant && merchant.id" class="col-12">
-      <direct-messages
-        ref="directMessagesRef"
-        :inkey="g.user.wallets[0].inkey"
-        :adminkey="g.user.wallets[0].adminkey"
-        :active-chat-customer="activeChatCustomer"
-        :merchant-id="merchant.id"
-        @customer-selected="filterOrdersForCustomer"
-        @order-selected="showOrderDetails"
-      >
-      </direct-messages>
-    </div>
   </div>
 
   <div>


### PR DESCRIPTION
## Summary

- Remove duplicate direct-messages component from sidebar (already exists in Messages tab)
- Remove duplicate info panel from main sidebar
- Move Nostr connection status button to header bar (left of Publish button)
- Restructure Merchant tab with two-column layout:
  - **Left column (col-md-8)**: Q-Card containing merchant controls (Merchant dropdown, Orders toggle, Restart button, Keys)
  - **Right column (col-md-4)**: Q-Card containing Nostr Market info panel with help sections and links

## Test plan

- [x] Verify Merchant tab shows two Q-Cards side by side
- [x] Verify info panel only appears on Merchant tab (not other tabs)
- [x] Verify Messages tab shows direct-messages component
- [x] Verify connection button appears in header for admin users
- [ ] Verify all tabs function correctly

## Screenshot

<img width="1469" height="947" alt="image" src="https://github.com/user-attachments/assets/4bf0b30e-8808-434f-8ab7-264995250796" />

🤖 Definitely not generated with [Claude Code](https://claude.com/claude-code)